### PR TITLE
Add sponsors component

### DIFF
--- a/src/apps/ConferenceApp/ConferenceApp.tsx
+++ b/src/apps/ConferenceApp/ConferenceApp.tsx
@@ -1,12 +1,27 @@
 import React from "react";
 import { BrowserRouter as Router, Route } from "react-router-dom";
-import { Header, Footer, NavLink, PageSection, Banner, About, Sponsors, Speakers, InfoIcon, Team, MapsLocation } from "../../components";
+import {
+  Header,
+  Footer,
+  NavLink,
+  PageSection,
+  Banner,
+  About,
+  Sponsors,
+  Speakers,
+  InfoIcon,
+  Team,
+  MapsLocation,
+  ActionButton,
+  SponsorshipPackages
+} from "../../components";
 import { Conduct, Schedule } from "../../pages";
 import { backendService } from "../../services";
 
 import { IProps, IState } from "./types";
 import styles from "./ConferenceApp.module.scss";
 import { IEdition } from "../../types/IConference";
+import constants from "../../constants";
 
 const sortByName = (itemA: any, itemB: any) => {
   if (itemA.name < itemB.name) return -1;
@@ -32,8 +47,12 @@ const Home: React.SFC<any> = ({ edition }: { edition: IEdition }) => {
       <PageSection id="speakers" title="Speakers" type="odd">
         <Speakers />
       </PageSection>
-      <PageSection id="sponsors" title="Sponsors">
-        <Sponsors />
+      <PageSection className={styles.centeredColumn} id="sponsors" title="Sponsors">
+        <div style={{ width: "100%", textAlign: "center" }}>
+          <ActionButton type="tertiary" text="Quiero ser sponsor" url={constants.sponsorsCallUrl} />
+        </div>
+        <SponsorshipPackages type="odd" />
+        <Sponsors title="Quienes nos acompañan" />
       </PageSection>
       <PageSection id="team" title="Organizadores" type="odd">
         <Team team={editionOrganizers} type="odd" />

--- a/src/components/Sponsors/Sponsors.module.scss
+++ b/src/components/Sponsors/Sponsors.module.scss
@@ -3,13 +3,30 @@
 .sponsors {
   @extend %pageSection;
   @extend %flexColumn;
-  align-items: center;
-  
   position: relative;
   z-index: 1;
 
   width: 100%;
-  min-height: 621px;
+}
+
+.title {
+  text-align: center;
+}
+
+.sponsorsRow {
+  @extend %flexRow;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.sponsor {
+  width: 250px;
+  height: 100px;
+  margin: 0 30px 30px 0;
+
+  &:hover {
+    background-color: rgba($secondaryBackgroundColor, 0.20);
+  }
 }
 
 @media 

--- a/src/components/Sponsors/Sponsors.tsx
+++ b/src/components/Sponsors/Sponsors.tsx
@@ -1,24 +1,61 @@
 import React from "react";
 import classNames from "classnames";
-import { ActionButton, SponsorshipPackages } from "..";
-import constants from "../../constants";
 
+import { ISponsor } from "../../types/ISponsor";
 import { Props, State } from "./types";
 import styles from "./Sponsors.module.scss";
 
+const Sponsor = ({ sponsor }: { sponsor: ISponsor }) => {
+  const cssClass = classNames(styles.sponsor, styles[sponsor.type]);
+
+  return (
+    <a className={cssClass} href={`${sponsor.url}?ref=vopen`} target="_blank">
+      <img className={styles.sponsorImage} src={sponsor.imageUrl} />
+    </a>
+  );
+};
+
 export default class Sponsors extends React.PureComponent<Props, State> {
   static defaultProps: Partial<Props> = {
-    className: undefined
+    className: undefined,
+    title: "",
+    sponsors: []
   };
 
   render() {
-    const { className } = this.props;
+    const { className, title, sponsors } = this.props;
     const cssClasses = classNames(styles.sponsors, className);
+
+    if (!sponsors || !sponsors.length) {
+      return null;
+    }
+
+    const diamondSponsors = sponsors.filter(item => item.type === "diamond");
+    const goldSponsors = sponsors.filter(item => item.type === "gold");
+    const silverSponsors = sponsors.filter(item => item.type === "silver");
+    const digitalSponsors = sponsors.filter(item => item.type === "digital");
+    const otherSponsors = sponsors.filter(item => item.type !== "diamond" && item.type !== "gold" && item.type !== "silver" && item.type !== "digital");
+
+    const Sponsors = ({ items }: { items: ISponsor[] }) => (
+      <div className={styles.sponsorsRow}>
+        {items.map(item => (
+          <Sponsor key={item.id} sponsor={item} />
+        ))}
+      </div>
+    );
 
     return (
       <div className={cssClasses}>
-        <ActionButton type="tertiary" text="Quiero ser sponsor" url={constants.sponsorsCallUrl} />
-        <SponsorshipPackages type="odd" />
+        {title && (
+          <div className={styles.title}>
+            <h3>{title}</h3>
+          </div>
+        )}
+        <Sponsors items={diamondSponsors} />
+        <Sponsors items={goldSponsors} />
+        <Sponsors items={silverSponsors} />
+        <Sponsors items={digitalSponsors} />
+        <Sponsors items={otherSponsors} />
       </div>
     );
   }

--- a/src/components/Sponsors/types.ts
+++ b/src/components/Sponsors/types.ts
@@ -1,5 +1,9 @@
+import { ISponsor } from "../../types/ISponsor";
+
 export interface Props {
   className?: string;
+  title?: string;
+  sponsors?: ISponsor[];
 }
 
 export interface State {}

--- a/src/services/backendService.ts
+++ b/src/services/backendService.ts
@@ -11,7 +11,7 @@ async function fetchConference(conferenceId: string): Promise<IConference | unde
     return result.data;
   } catch (error) {
     console.error(error);
-    return;
+    return undefined;
   }
 }
 

--- a/src/types/IConference.ts
+++ b/src/types/IConference.ts
@@ -1,4 +1,5 @@
 import { IOrganizer } from "./IOrganizer";
+import { ISponsor } from "./ISponsor";
 
 export interface IConference {
   id: string;
@@ -21,4 +22,5 @@ export interface IEdition {
     isTicketSaleOpen: boolean;
   };
   organizers: IOrganizer[];
+  sponsors: ISponsor[];
 }

--- a/src/types/ISponsor.ts
+++ b/src/types/ISponsor.ts
@@ -1,0 +1,8 @@
+export interface ISponsor {
+  id: string;
+  name: string;
+  country: string;
+  imageUrl: string;
+  url: string;
+  type: string;
+}


### PR DESCRIPTION
This PR adds the sponsor component that displays the sponsors in different rows, one per sponsor type (diamond first, then gold, silver and digital last).

![image](https://user-images.githubusercontent.com/1306634/60473149-2d1a8c80-9c42-11e9-941f-aa74681dbcf4.png)

---

To display them, paste this code in the component:

```ts
const getDummySponsors = () => {
  const dummySponsor = {
    id: "ms",
    name: "Microsoft",
    country: "ARG",
    imageUrl: "http://ar.netconf.global/Content/images/demo/sponsor-logos/microsoft.png",
    url: "https://www.microsoft.com/",
    type: "diamond"
  };

  return [
    { ...dummySponsor },
    { ...dummySponsor, type: "gold" },
    { ...dummySponsor, type: "gold" },
    { ...dummySponsor, type: "gold" },
    { ...dummySponsor, type: "silver" },
    { ...dummySponsor, type: "silver" },
    { ...dummySponsor, type: "silver" },
    { ...dummySponsor, type: "silver" },
    { ...dummySponsor, type: "digital" },
    { ...dummySponsor, type: "digital" }
  ];
};
```