### PR TITLE
Split team between local and global organizers

### DIFF
--- a/src/apps/ConferenceApp/ConferenceApp.module.scss
+++ b/src/apps/ConferenceApp/ConferenceApp.module.scss
@@ -20,6 +20,11 @@
   }
 }
 
+.centeredText {
+  width: 100%;
+  text-align: center;
+}
+
 @media 
   only screen and (max-device-width: 900px),
   only screen and (max-width: 900px) {

--- a/src/apps/ConferenceApp/types.ts
+++ b/src/apps/ConferenceApp/types.ts
@@ -6,4 +6,5 @@ export interface IProps {
 
 export interface IState {
   conferenceData?: IConference;
+  globalData?: IConference;
 }


### PR DESCRIPTION
This PR changes the conference app code to also retrieve the data from the global conference. With both, we render the local and global team separately.

It also has minor renames and a refactor in styles.