### PR TITLE
Move schedule to its own page

### DIFF
--- a/src/apps/ConferenceApp/ConferenceApp.tsx
+++ b/src/apps/ConferenceApp/ConferenceApp.tsx
@@ -9,7 +9,6 @@ import {
   CtaButtons,
   Sponsors,
   Speakers,
-  Schedule,
   Team,
   Tickets,
   MapsLocation,
@@ -31,7 +30,7 @@ const sortByName = (itemA: any, itemB: any) => {
   return 0;
 };
 
-  const Home: React.SFC<any> = ({ conferenceInfo, globalInfo }: { conferenceInfo: IEdition; globalInfo: IEdition }) => {
+const Home: React.SFC<any> = ({ conferenceInfo, globalInfo }: { conferenceInfo: IEdition; globalInfo: IEdition }) => {
   const Resources = resourcesService.getResources();
 
   const isTicketSaleEnabled = conferenceInfo.editionTickets && conferenceInfo.editionTickets.length > 0;
@@ -40,46 +39,36 @@ const sortByName = (itemA: any, itemB: any) => {
   const conferenceOrganizers = conferenceInfo.organizers ? conferenceInfo.organizers.sort(sortByName) : [];
   const conferenceSpeakers = conferenceInfo.speakers || [];
   const conferenceSponsors = conferenceInfo.sponsors || [];
-  const conferenceActivities = conferenceInfo.activities || {};
-  const isScheduleEnabled = conferenceActivities.days && conferenceActivities.days.length > 0;
 
   return (
     <>
       <HeroConf to="#about" subtitle={conferenceTitle} title={Resources.titles.homePage} type="odd">
-        </HeroConf>
-      <PageSection id="about"  type="even" className="pv6">
-        <CtaButtons className="pt5"/>
+      </HeroConf>
+      <PageSection id="about" type="even" className="pv6">
+        <CtaButtons className="pt5" />
       </PageSection>
       <PageSection id="speakers">
-      <div className={styles.banner}>
+        <div className={styles.banner}>
           <h1 className={styles.subtitle}>{Resources.pages.speakers}</h1>
         </div>
         <Speakers speakers={conferenceSpeakers} />
       </PageSection>
       <PageSection className="tc bg-near-white" id="sponsors">
-      <div className={styles.banner}>
-        <h2 className={styles.tag}>{Resources.pages.sponsors}</h2>
+        <div className={styles.banner}>
+          <h2 className={styles.tag}>{Resources.pages.sponsors}</h2>
           <h1 className={styles.subtitle}>{Resources.titles.sponsors}</h1>
           <div className="pt5">
-          <ActionButton type="secondary" text={Resources.buttons.wantToBeSponsors} url={constants.sponsorsCallUrl} target="_blank"/>
+            <ActionButton type="secondary" text={Resources.buttons.wantToBeSponsors} url={constants.sponsorsCallUrl} target="_blank" />
           </div>
         </div>
         <Sponsors sponsors={conferenceSponsors} />
       </PageSection>
       {isTicketSaleEnabled && (
         <PageSection className={styles.centeredColumn} id="tickets" type="odd">
-                    <div className={styles.banner}>
-          <h1 className={styles.subtitle}>{Resources.pages.tickets}</h1>
-        </div>
-          <Tickets tickets={conferenceInfo.editionTickets} />
-        </PageSection>
-      )}
-      {isScheduleEnabled && (
-        <PageSection id="schedule" className="pv5">
           <div className={styles.banner}>
-          <h1 className={styles.subtitle}>{Resources.pages.schedule}</h1>
-        </div>
-          <Schedule activities={conferenceActivities} />
+            <h1 className={styles.subtitle}>{Resources.pages.tickets}</h1>
+          </div>
+          <Tickets tickets={conferenceInfo.editionTickets} />
         </PageSection>
       )}
       <PageSection id="team" className="bg-near-white">
@@ -87,7 +76,7 @@ const sortByName = (itemA: any, itemB: any) => {
           <h2 className={styles.tag}>{Resources.pages.team}</h2>
           <h1 className={styles.subtitle}>{Resources.titles.sloganTeam}</h1>
         </div>
-        <Team team={conferenceOrganizers}  className="pt4"/>
+        <Team team={conferenceOrganizers} className="pt4" />
       </PageSection>
       <PageSection id="location" type="full">
         <MapsLocation address={conferenceInfo.locationFullAddress} />
@@ -122,11 +111,14 @@ export default class ConferenceApp extends React.PureComponent<IProps, IState> {
 
     const Resources = resourcesService.getResources();
 
+    const conferenceActivities = conferenceData.activities || {};
+    const isScheduleEnabled = conferenceActivities.days && conferenceActivities.days.length > 0;
+
     return (
       <Router>
         <div className={styles.conferenceApp}>
           <Header type="odd">
-            <NavLink to="/#schedule" />
+            {isScheduleEnabled && <NavLink to="/schedule">{Resources.pages.schedule}</NavLink>}
             <NavLink to="/#speakers">{Resources.pages.speakers}</NavLink>
             <NavLink to="/#sponsors">{Resources.pages.sponsors}</NavLink>
             <NavLink to="/conduct"> {Resources.pages.codeOfConduct}</NavLink>
@@ -136,7 +128,7 @@ export default class ConferenceApp extends React.PureComponent<IProps, IState> {
           </Header>
           {/* Body */}
           <Route exact path="/" render={() => <Home conferenceInfo={conferenceData} globalInfo={globalData} />} />
-          <Route path="/schedule" component={SchedulePage} />
+          <Route path="/schedule" render={() => <SchedulePage activities={conferenceActivities} />} />
           <Route path="/conduct" component={ConductPage} />
           <Route path="/team" component={Team} />
           {/* End body */}

--- a/src/components/Sponsors/Sponsors.module.scss
+++ b/src/components/Sponsors/Sponsors.module.scss
@@ -2,7 +2,6 @@
 
 .sponsors {
   @extend %container;
-  padding: 0 50px;
 
 .title {
   text-align: center;

--- a/src/pages/SchedulePage/SchedulePage.module.scss
+++ b/src/pages/SchedulePage/SchedulePage.module.scss
@@ -4,3 +4,18 @@
   @extend %container;
   padding: 0 50px;
 }
+
+.banner {
+  @extend %container;
+  padding: 5rem 0 2rem;
+  .subtitle {
+    @extend %subtitle;
+    width: 70%;
+    margin: 0 auto;
+  }
+  .tag {
+    @extend %tag;
+    text-transform: uppercase;
+  }
+
+}

--- a/src/pages/SchedulePage/SchedulePage.tsx
+++ b/src/pages/SchedulePage/SchedulePage.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Schedule, PageSection } from "../../components";
+import { resourcesService } from "../../services";
 
 import styles from "./SchedulePage.module.scss";
 import { Props } from "./types";
@@ -7,9 +8,13 @@ import { Props } from "./types";
 export default class SchedulePage extends React.PureComponent<Props> {
   render() {
     const { activities } = this.props;
+    const Resources = resourcesService.getResources();
     return (
       <>
         <PageSection className={styles.schedulePage}>
+        <div className={styles.banner}>
+          <h1 className={styles.subtitle}>{Resources.pages.schedule}</h1>
+        </div>
           <Schedule activities={activities} />
         </PageSection>
       </>

--- a/src/pages/SchedulePage/SchedulePage.tsx
+++ b/src/pages/SchedulePage/SchedulePage.tsx
@@ -1,17 +1,18 @@
 import React from "react";
-import { resourcesService } from "../../services";
-import styles from "./SchedulePage.module.scss";
 import { Schedule, PageSection } from "../../components";
-import { IEdition } from "../../types/IEdition";
 
-export default class SchedulePage extends React.PureComponent {
+import styles from "./SchedulePage.module.scss";
+import { Props } from "./types";
+
+export default class SchedulePage extends React.PureComponent<Props> {
   render() {
+    const { activities } = this.props;
     return (
       <>
-      <PageSection className={styles.schedulePage}>
-          <Schedule />
+        <PageSection className={styles.schedulePage}>
+          <Schedule activities={activities} />
         </PageSection>
-        </>
+      </>
     )
   }
 }

--- a/src/pages/SchedulePage/types.ts
+++ b/src/pages/SchedulePage/types.ts
@@ -1,0 +1,5 @@
+import { IEditionActivities } from "../../types/IEditionActivities";
+
+export interface Props {
+  activities: IEditionActivities
+}


### PR DESCRIPTION
This PR moves the Schedule to its own page. 

For this we:

1. Removed the Schedule component from the main page.
1. Added a link to the Schedule page in the main page
    ![image](https://user-images.githubusercontent.com/1306634/75097562-e4299680-558a-11ea-951d-a5d55bfbc9ff.png)
1. Updated the Schedule page to receive the conference activities data. 
    ![image](https://user-images.githubusercontent.com/1306634/75097584-14713500-558b-11ea-8f56-a531f75d1267.png)

Note that we still have to implement its own style.
