### PR TITLE
Move sponsorship packages to its own page

### DIFF
--- a/src/apps/ConferenceApp/ConferenceApp.tsx
+++ b/src/apps/ConferenceApp/ConferenceApp.tsx
@@ -61,7 +61,7 @@ const Home: React.SFC<any> = ({ conferenceInfo, globalInfo }: { conferenceInfo: 
           <h2 className={styles.tag}>{Resources.pages.sponsors}</h2>
           <h1 className={styles.subtitle}>{Resources.titles.sponsors}</h1>
           <div className="pt5">
-            <ActionButton type="secondary" text={Resources.buttons.wantToBeSponsors} url={constants.sponsorsCallUrl} target="_blank" />
+            <ActionButton type="secondary" text={Resources.buttons.learnMore} url="/sponsorship" target="_self" />
           </div>
         </div>
         <Sponsors sponsors={conferenceSponsors} />
@@ -127,7 +127,6 @@ export default class ConferenceApp extends React.PureComponent<IProps, IState> {
         <div className={styles.conferenceApp}>
           <Header type="odd">
             <NavLink to="/#schedule" />
-            <NavLink to="/sponsorship">{Resources.pages.sponsorship}</NavLink>
             <NavLink to="/#speakers">{Resources.pages.speakers}</NavLink>
             <NavLink to="/#sponsors">{Resources.pages.sponsors}</NavLink>
             <NavLink to="/conduct"> {Resources.pages.codeOfConduct}</NavLink>

--- a/src/apps/ConferenceApp/ConferenceApp.tsx
+++ b/src/apps/ConferenceApp/ConferenceApp.tsx
@@ -18,7 +18,7 @@ import {
 
 } from "../../components";
 import constants from "../../constants";
-import { ConductPage, SchedulePage } from "../../pages";
+import { ConductPage, SchedulePage, SponsorsPage } from "../../pages";
 import { backendService, resourcesService, siteService } from "../../services";
 
 import { IProps, IState } from "./types";
@@ -31,7 +31,7 @@ const sortByName = (itemA: any, itemB: any) => {
   return 0;
 };
 
-  const Home: React.SFC<any> = ({ conferenceInfo, globalInfo }: { conferenceInfo: IEdition; globalInfo: IEdition }) => {
+const Home: React.SFC<any> = ({ conferenceInfo, globalInfo }: { conferenceInfo: IEdition; globalInfo: IEdition }) => {
   const Resources = resourcesService.getResources();
 
   const isTicketSaleEnabled = conferenceInfo.editionTickets && conferenceInfo.editionTickets.length > 0;
@@ -46,39 +46,39 @@ const sortByName = (itemA: any, itemB: any) => {
   return (
     <>
       <HeroConf to="#about" subtitle={conferenceTitle} title={Resources.titles.homePage} type="odd">
-        </HeroConf>
-      <PageSection id="about"  type="even" className="pv6">
-        <CtaButtons className="pt5"/>
+      </HeroConf>
+      <PageSection id="about" type="even" className="pv6">
+        <CtaButtons className="pt5" />
       </PageSection>
       <PageSection id="speakers">
-      <div className={styles.banner}>
+        <div className={styles.banner}>
           <h1 className={styles.subtitle}>{Resources.pages.speakers}</h1>
         </div>
         <Speakers speakers={conferenceSpeakers} />
       </PageSection>
       <PageSection className="tc bg-near-white" id="sponsors">
-      <div className={styles.banner}>
-        <h2 className={styles.tag}>{Resources.pages.sponsors}</h2>
+        <div className={styles.banner}>
+          <h2 className={styles.tag}>{Resources.pages.sponsors}</h2>
           <h1 className={styles.subtitle}>{Resources.titles.sponsors}</h1>
           <div className="pt5">
-          <ActionButton type="secondary" text={Resources.buttons.wantToBeSponsors} url={constants.sponsorsCallUrl} target="_blank"/>
+            <ActionButton type="secondary" text={Resources.buttons.wantToBeSponsors} url={constants.sponsorsCallUrl} target="_blank" />
           </div>
         </div>
         <Sponsors sponsors={conferenceSponsors} />
       </PageSection>
       {isTicketSaleEnabled && (
         <PageSection className={styles.centeredColumn} id="tickets" type="odd">
-                    <div className={styles.banner}>
-          <h1 className={styles.subtitle}>{Resources.pages.tickets}</h1>
-        </div>
+          <div className={styles.banner}>
+            <h1 className={styles.subtitle}>{Resources.pages.tickets}</h1>
+          </div>
           <Tickets tickets={conferenceInfo.editionTickets} />
         </PageSection>
       )}
       {isScheduleEnabled && (
         <PageSection id="schedule" className="pv5">
           <div className={styles.banner}>
-          <h1 className={styles.subtitle}>{Resources.pages.schedule}</h1>
-        </div>
+            <h1 className={styles.subtitle}>{Resources.pages.schedule}</h1>
+          </div>
           <Schedule activities={conferenceActivities} />
         </PageSection>
       )}
@@ -87,7 +87,7 @@ const sortByName = (itemA: any, itemB: any) => {
           <h2 className={styles.tag}>{Resources.pages.team}</h2>
           <h1 className={styles.subtitle}>{Resources.titles.sloganTeam}</h1>
         </div>
-        <Team team={conferenceOrganizers}  className="pt4"/>
+        <Team team={conferenceOrganizers} className="pt4" />
       </PageSection>
       <PageSection id="location" type="full">
         <MapsLocation address={conferenceInfo.locationFullAddress} />
@@ -127,6 +127,7 @@ export default class ConferenceApp extends React.PureComponent<IProps, IState> {
         <div className={styles.conferenceApp}>
           <Header type="odd">
             <NavLink to="/#schedule" />
+            <NavLink to="/sponsorship">{Resources.pages.sponsorship}</NavLink>
             <NavLink to="/#speakers">{Resources.pages.speakers}</NavLink>
             <NavLink to="/#sponsors">{Resources.pages.sponsors}</NavLink>
             <NavLink to="/conduct"> {Resources.pages.codeOfConduct}</NavLink>
@@ -137,6 +138,7 @@ export default class ConferenceApp extends React.PureComponent<IProps, IState> {
           {/* Body */}
           <Route exact path="/" render={() => <Home conferenceInfo={conferenceData} globalInfo={globalData} />} />
           <Route path="/schedule" component={SchedulePage} />
+          <Route path="/sponsorship" render={() => <SponsorsPage />} />
           <Route path="/conduct" component={ConductPage} />
           <Route path="/team" component={Team} />
           {/* End body */}

--- a/src/components/SponsorshipPackages/SponsorshipPackages.module.scss
+++ b/src/components/SponsorshipPackages/SponsorshipPackages.module.scss
@@ -3,10 +3,12 @@
 .sponsorship {
   @extend %container;
   padding: 20px;
+  color: $primaryColor;
 }
 
 .banner {
   @extend %banner;
+  color: $primaryColor;
 }
 
 .tag {

--- a/src/pages/SponsorsPage/SponsorsPage.tsx
+++ b/src/pages/SponsorsPage/SponsorsPage.tsx
@@ -8,12 +8,13 @@ import styles from "./SponsorsPage.module.scss";
 export default class SponsorsPage extends React.PureComponent<Props> {
   render() {
     const { sponsors = [] } = this.props;
+    const showSponsors = sponsors && sponsors.length > 0;
     const Resources = resourcesService.getResources();
 
     return (
       <div className={styles.sponsorsPage}>
         <SponsorshipPackages className={styles.sponsorshipPackages} />
-        <Sponsors className={styles.sponsors} title={Resources.titles.sponsorPage} sponsors={sponsors} />
+        {showSponsors && <Sponsors className={styles.sponsors} title={Resources.titles.sponsorPage} sponsors={sponsors} />}
       </div>
     );
   }

--- a/src/resources/en-US.json
+++ b/src/resources/en-US.json
@@ -11,6 +11,7 @@
   "buttons": {
     "wantToBeSponsors": "support us",
     "wantToBeSpeaker": "join",
+    "learnMore": "learn more",
     "wantToReceiveNews": "subscribe",
     "register": "register",
     "as": "as",

--- a/src/resources/es-AR.json
+++ b/src/resources/es-AR.json
@@ -11,6 +11,7 @@
   "buttons": {
     "wantToBeSponsors": "Apoyanos",
     "wantToBeSpeaker": "sumate",
+    "learnMore": "enterate como",
     "wantToReceiveNews": "suscribite",
     "register": "registrate",
     "as": "como",


### PR DESCRIPTION
This PR moves the Sponsorship packages to its own page, for the Conferences app.

![image](https://user-images.githubusercontent.com/1306634/75097717-b80f1500-558c-11ea-8af3-5b97a7013a96.png)
